### PR TITLE
升级小版本至2.1.3。

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,14 @@
 <dependency>
     <groupId>cn.sanenen</groupId>
     <artifactId>sun-utils</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
 </dependency>
 ```
+### 更新日志
+2.1.3:
+- 修正持久化队列，关闭应用时可能出现hs_err错误文件的问题。
+
+
 ```
 ├─src
 ├─main

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cn.sanenen</groupId>
     <artifactId>sun-utils</artifactId>
-    <version>2.1.2</version>
+    <version>2.1.3</version>
     <packaging>jar</packaging>
 
     <name>sun-utils</name>

--- a/src/main/java/cn/sanenen/queue/data/DataIndex.java
+++ b/src/main/java/cn/sanenen/queue/data/DataIndex.java
@@ -39,10 +39,11 @@ public class DataIndex {
 	private FileChannel fc;
 	private MappedByteBuffer mappedByteBuffer;
 	private final ExecutorService executor = Executors.newSingleThreadExecutor();
+	private boolean syncRunFlag = true;
 
 	private ByteBuffer readerBuffer;
 	private ByteBuffer writerBuffer;
-	
+
 	private int readerIndex = 1;
 	private int writerIndex = 1;
 	private AtomicLong size = new AtomicLong();
@@ -120,7 +121,7 @@ public class DataIndex {
 	private class Sync implements Runnable {
 		@Override
 		public void run() {
-			while (true) {
+			while (syncRunFlag) {
 				if (mappedByteBuffer != null) {
 					try {
 						mappedByteBuffer.position(20);
@@ -149,6 +150,7 @@ public class DataIndex {
 			fc = null;
 			mappedByteBuffer = null;
 			dbRandFile = null;
+			syncRunFlag = false;
 			executor.shutdown();
 		} catch (IOException e) {
 			log.error("close index file error:", e);


### PR DESCRIPTION
1、修正持久化队列，关闭应用时可能出现hs_err错误文件的问题。